### PR TITLE
Updates dependencies to build with GHC 9.2.7 and 9.4.4

### DIFF
--- a/bitcoin-compact-filters.cabal
+++ b/bitcoin-compact-filters.cabal
@@ -17,13 +17,14 @@ data-files:
 tested-with:
     GHC == 8.10.7
   , GHC == 9.0.2
-  , GHC == 9.2.2
+  , GHC == 9.2.7
+  , GHC == 9.4.4
 
 common core
   default-language: Haskell2010
   ghc-options:      -Wall
   build-depends:
-      base >=4.12 && <4.17
+      base >=4.12 && <4.19
     , bytestring >=0.10 && <0.12
     , cereal ^>=0.5
     , haskoin-core >=0.17.1 && <0.22
@@ -39,7 +40,7 @@ library
 
   build-depends:
       transformers >=0.5 && <0.7
-    , memory >=0.15 && <0.18
+    , memory >=0.15 && <0.19
 
 
 test-suite bitcoin-cf-tests
@@ -60,7 +61,7 @@ test-suite bitcoin-cf-tests
     Paths_bitcoin_compact_filters
 
   build-depends:
-      aeson >=1.0 && <2.1
+      aeson >=1.0 && <2.2
     , bitcoin-compact-filters
     , tasty >=1.0 && <1.5
     , tasty-hunit >=0.9 && <0.11


### PR DESCRIPTION
There's a bit more work to make it build with 9.6 as `haskoin-core` doesn't
built with it yet seems some dependencies need to be updated there as well.

Using GHCUP I made sure it built successfully and tests pass.