### PR TITLE
Bump to haskoin-core v1.x

### DIFF
--- a/bitcoin-compact-filters.cabal
+++ b/bitcoin-compact-filters.cabal
@@ -27,7 +27,7 @@ common core
       base >=4.12 && <4.19
     , bytestring >=0.10 && <0.12
     , cereal ^>=0.5
-    , haskoin-core >=0.17.1 && <0.22
+    , haskoin-core >=0.17.1 && <2.0
     , text >=1.2 && <2.1
 
      

--- a/src/Bitcoin/CompactFilter.hs
+++ b/src/Bitcoin/CompactFilter.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -Wno-type-defaults #-}
 
 module Bitcoin.CompactFilter (
@@ -115,9 +116,11 @@ filterContents ::
 filterContents prev b = filter scriptFilter prev <> these
   where
     these = filter scriptFilter . fmap scriptOutput $ blockTxns b >>= txOut
+#if MIN_VERSION_haskoin_core(1, 0, 0)
     scriptOutput TxOut{script} = script
     txOut Tx{outputs} = outputs
     blockTxns Block{txs} = txs
+#endif
     scriptFilter scr = not (BS.null scr) && contentFilter scr
 
     contentFilter bs = case decode bs of
@@ -133,7 +136,9 @@ encodeFilter ::
 encodeFilter os b = BlockFilter s
   where
     h = headerHash $ blockHeader b
+#if MIN_VERSION_haskoin_core(1, 0, 0)
     blockHeader Block{header} = header
+#endif
     bs = toSet $ filterContents os b
     s = hashedSetConstruct (sipKey h) paramM (length bs) bs
 

--- a/src/Bitcoin/CompactFilter.hs
+++ b/src/Bitcoin/CompactFilter.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# OPTIONS_GHC -Wno-type-defaults #-}
 
 module Bitcoin.CompactFilter (
@@ -50,15 +51,13 @@ import Data.Serialize (
 import Data.Text (Text)
 import Data.Word (Word64, Word8)
 import Haskoin.Block (
-    Block,
+    Block (..),
     BlockHash,
-    blockHeader,
-    blockTxns,
     headerHash,
  )
 import Haskoin.Crypto (Hash256, doubleSHA256)
 import Haskoin.Script (Script (..), ScriptOp (..))
-import Haskoin.Transaction (scriptOutput, txOut)
+import Haskoin.Transaction (Tx (..), TxOut (..))
 import Haskoin.Util (decodeHex, encodeHex)
 
 -- | SIP hash parameter
@@ -116,6 +115,9 @@ filterContents ::
 filterContents prev b = filter scriptFilter prev <> these
   where
     these = filter scriptFilter . fmap scriptOutput $ blockTxns b >>= txOut
+    scriptOutput TxOut{script} = script
+    txOut Tx{outputs} = outputs
+    blockTxns Block{txs} = txs
     scriptFilter scr = not (BS.null scr) && contentFilter scr
 
     contentFilter bs = case decode bs of
@@ -131,6 +133,7 @@ encodeFilter ::
 encodeFilter os b = BlockFilter s
   where
     h = headerHash $ blockHeader b
+    blockHeader Block{header} = header
     bs = toSet $ filterContents os b
     s = hashedSetConstruct (sipKey h) paramM (length bs) bs
 


### PR DESCRIPTION
Haskoin uses `NoFieldSelectors` which means we could only access record fields
via explicit pattern matching or in this case using `NamedFieldPuns` without
resorting to `RecordDotSyntax`.

This also fixes building the package on GHC 9.4.8.

If we don't want this, an alternative is to keep `haskoin-core` as is and fix
by adding some constraints to a `cabal.project` file.