### PR TITLE
bump version constraints, update to haskoin-core 1.1.0

### DIFF
--- a/bitcoin-compact-filters.cabal
+++ b/bitcoin-compact-filters.cabal
@@ -24,11 +24,11 @@ common core
   default-language: Haskell2010
   ghc-options:      -Wall
   build-depends:
-      base >=4.12 && <4.19
-    , bytestring >=0.10 && <0.12
+      base >=4.12 && <4.20
+    , bytestring >=0.10 && <0.13
     , cereal ^>=0.5
-    , haskoin-core >=0.17.1 && <2.0
-    , text >=1.2 && <2.1
+    , haskoin-core >=1.0.1 && <1.2
+    , text >=1.2 && <2.2
 
      
 library
@@ -61,8 +61,8 @@ test-suite bitcoin-cf-tests
     Paths_bitcoin_compact_filters
 
   build-depends:
-      aeson >=1.0 && <2.2
+      aeson >=1.0 && <2.3
     , bitcoin-compact-filters
-    , tasty >=1.0 && <1.5
+    , tasty >=1.0 && <1.6
     , tasty-hunit >=0.9 && <0.11
-    , tasty-quickcheck >=0.8.1 && <0.11
+    , tasty-quickcheck >=0.8.1 && <0.12

--- a/test/Test/CompactFilter.hs
+++ b/test/Test/CompactFilter.hs
@@ -2,16 +2,16 @@ module Test.CompactFilter (
     genBlockFilter,
 ) where
 
+import Bitcoin.CompactFilter (BlockFilter, encodeFilter)
 import Control.Monad (replicateM)
-import Haskoin.Constants (btc)
+import Haskoin.Crypto (Ctx)
+import Haskoin.Network.Constants (btc)
 import Haskoin.Util.Arbitrary.Block (arbitraryBlock)
 import Haskoin.Util.Arbitrary.Util (arbitraryBS1)
 import Test.Tasty.QuickCheck (Gen, choose)
 
-import Bitcoin.CompactFilter (BlockFilter, encodeFilter)
-
-genBlockFilter :: Gen BlockFilter
-genBlockFilter = encodeFilter <$> scripts <*> arbitraryBlock btc
+genBlockFilter :: Ctx -> Gen BlockFilter
+genBlockFilter ctx = encodeFilter <$> scripts <*> arbitraryBlock btc ctx
   where
     scripts = do
         n <- choose (1, 100)


### PR DESCRIPTION
- bumped version constraints for stackage LTS 23.0 and haskoin-core 1.1.0
- renamed module import from `Haskoin.Constants` to `Haskoin.Network.Constants`
- updated tests to support haskoin-core 1.0>, using the new record names and functions that take a Ctx argument