### PR TITLE
Bump upper bound for base, haskoin-core

### DIFF
--- a/bitcoin-compact-filters.cabal
+++ b/bitcoin-compact-filters.cabal
@@ -24,10 +24,10 @@ common core
   default-language: Haskell2010
   ghc-options:      -Wall
   build-depends:
-      base >=4.12 && <4.20
+      base >=4.12 && <4.21
     , bytestring >=0.10 && <0.13
     , cereal ^>=0.5
-    , haskoin-core >=1.0.1 && <1.2
+    , haskoin-core >=1.0.1 && <1.3
     , text >=1.2 && <2.2
 
      


### PR DESCRIPTION
This PR updates the upper bound for `base` to allow this to build with stackage LTS 24